### PR TITLE
PROJ-1180-CLONE-I-don-t-see-my-announcement-on-the-dashboard

### DIFF
--- a/src/components/lpikit/AnnouncementCard/AnnouncementCard.vue
+++ b/src/components/lpikit/AnnouncementCard/AnnouncementCard.vue
@@ -32,7 +32,7 @@
             <div class="announcement-project horizontal-padding top-padding bottom-padding">
                 <div
                     :style="{
-                        'background-image': `url(${announcement.project.header_image.variations.small})`,
+                        'background-image': projectImage,
                     }"
                     class="picto"
                 ></div>
@@ -62,6 +62,14 @@ export default {
         announcement: {
             type: Object,
             required: true,
+        },
+    },
+
+    computed: {
+        projectImage() {
+            return `url(${this.announcement.project?.header_image?.variations?.small}), url(${
+                import.meta.env.VITE_APP_PUBLIC_BINARIES_PREFIX
+            }/patatoids-project/Patatoid-1.png)`
         },
     },
 }


### PR DESCRIPTION
fix: null project image in announcement card