### PR TITLE
PROJ-1260-dates-in-Project-blogs-are-broken

### DIFF
--- a/src/pages/ProjectPage/Tabs/BlogEntries/ProjectBlogEntriesTab.vue
+++ b/src/pages/ProjectPage/Tabs/BlogEntries/ProjectBlogEntriesTab.vue
@@ -91,7 +91,7 @@ export default {
                 return {
                     id: blogEntry.id,
                     label: blogEntry.title,
-                    date: blogEntry.updated_at,
+                    date: blogEntry.created_at,
                 }
             })
         },

--- a/src/store/modules/projects.ts
+++ b/src/store/modules/projects.ts
@@ -31,6 +31,10 @@ export interface ProjectState {
     project: ProjectOutput
 }
 
+function sortBlogEntries(a: any, b: any) {
+    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+}
+
 const state = (): ProjectState => ({
     project: null,
 })
@@ -322,9 +326,11 @@ const mutations = {
     // BLOG ENTRIES
     SET_BLOG_ENTRIES: (state: ProjectState, blogEntries: BlogEntryOutput[]) => {
         state.project.blog_entries = blogEntries
+        state.project.blog_entries.sort(sortBlogEntries)
     },
     ADD_BLOG_ENTRY: (state: ProjectState, blogEntry: any) => {
         state.project.blog_entries.unshift(blogEntry)
+        state.project.blog_entries.sort(sortBlogEntries)
     },
     UPDATE_BLOG_ENTRY: (
         state: ProjectState,
@@ -334,6 +340,7 @@ const mutations = {
         }
     ) => {
         state.project.blog_entries.splice(body.index, 1, body.entry)
+        state.project.blog_entries.sort(sortBlogEntries)
     },
     DELETE_BLOG_ENTRY: (state: ProjectState, index: number) => {
         state.project.blog_entries.splice(index, 1)


### PR DESCRIPTION
fix: reorder blog entries on update and use creation date