### PR TITLE
PROJ-1229-an-editor-is-not-displayed-during-collaborative-editing

### DIFF
--- a/src/components/lpikit/TextEditor/TipTapEditor.vue
+++ b/src/components/lpikit/TextEditor/TipTapEditor.vue
@@ -285,7 +285,17 @@ export default {
         color: {
             type: String,
             // choose a random color for every user
-            default: '#' + Math.floor(Math.random() * Math.pow(2, 24)).toString(16),
+            default: () => {
+                function randomIntInRange(fromInclusive, toInclusive) {
+                    return Math.floor(
+                        Math.random() * (toInclusive - fromInclusive + 1) + fromInclusive
+                    )
+                }
+                const hue = randomIntInRange(0, 360) // any tint
+                const saturation = randomIntInRange(50, 100) // not too grey
+                const lightness = randomIntInRange(20, 60) // neither too dark nor too light
+                return `hsl(${hue}deg ${saturation}% ${lightness}%)`
+            },
         },
         mode: {
             // mode supports 3 values 'simple' | 'medium' | 'full'


### PR DESCRIPTION
fix: restrict user random color in editor to contrastive ones