### PR TITLE
PROJ-1326-Les-admins-ne-peuvent-plus-trier-les-utilisateurs-par-r-le

### DIFF
--- a/src/pages/AdminPortalPage/Tabs/AccountsTab.vue
+++ b/src/pages/AdminPortalPage/Tabs/AccountsTab.vue
@@ -217,7 +217,7 @@ export default {
             this.request = await searchPeopleProject({
                 search: this.searchFilter,
                 org_id: this.organization.id,
-                param: {
+                params: {
                     ordering: filter.order + filter.filter,
                 },
             })


### PR DESCRIPTION
fix: sort user admin table