### PR TITLE
PROJ-1423-Quand-on-quitte-le-tiroir-de-tags-lors-de-la-creation-de-projet-pendant-la-selection-de-desambiguation-la-barre-de-recherche-n-apparait-plus

### DIFF
--- a/src/components/lpikit/ProjectForm/ProjectForm.vue
+++ b/src/components/lpikit/ProjectForm/ProjectForm.vue
@@ -298,6 +298,7 @@ export default {
     methods: {
         closeTagSearchTags() {
             this.tagSearchIsOpened = false
+            this.ambiguousTagsOpen = false
         },
 
         saveTags() {


### PR DESCRIPTION
fix: project form add tag's disapearing search bar