### PR TITLE
PROJ-1573-sdg-in-project-redirects-to-genral-search

### DIFF
--- a/src/components/lpikit/ProjectHeader/ProjectHeader.vue
+++ b/src/components/lpikit/ProjectHeader/ProjectHeader.vue
@@ -206,7 +206,7 @@
                                 <router-link
                                     v-for="sdg in project?.sdgs || []"
                                     :key="sdg"
-                                    :to="browsePageWithQuery('sdgs', sdg)"
+                                    :to="browseProjectsWithQuery('sdgs', sdg)"
                                     class="sdg-link"
                                 >
                                     <img
@@ -637,11 +637,12 @@ export default {
             this.imageLoaded = true
         },
 
-        browsePageWithQuery(queryField, queryValue) {
+        browseProjectsWithQuery(queryField, queryValue) {
             return {
-                path: '/search',
+                name: 'ProjectSearch',
                 query: {
                     [queryField]: queryValue,
+                    section: 'projects',
                 },
             }
         },


### PR DESCRIPTION
fix: make sdg in project header redirect to a filtered project search