### PR TITLE
PROJ-1586-sur-chrome-les-tags-sont-coup-s-en-fin-deliste

### DIFF
--- a/src/components/lpikit/FilterTags/SearchResults.vue
+++ b/src/components/lpikit/FilterTags/SearchResults.vue
@@ -76,6 +76,7 @@ export default {
         gap: $space-m;
         align-items: stretch;
         padding-top: $space-l;
+        padding-bottom: $space-l;
         box-sizing: border-box;
 
         > * {


### PR DESCRIPTION
fix: cropped tag results on chrome in project edition