### PR TITLE
PROJ-1672-en-home-le-menu-de-recherche-passe-derrier-les-boutons

### DIFF
--- a/src/pages/NewHomePage/NewHomePage.vue
+++ b/src/pages/NewHomePage/NewHomePage.vue
@@ -117,6 +117,8 @@ export default {
     padding-bottom: $space-l;
     border-radius: $border-radius-17;
     flex-direction: row;
+    position: relative; // higher than home category dropdown and buttons and suggestions
+    z-index: 10;
 
     @media (min-width: $min-tablet) {
         padding-left: $space-2xl;


### PR DESCRIPTION
fix: home search dropdown appear behind other elements 