### PR TITLE
perf(ProjectPage): run setheader only in server

### DIFF
--- a/src/composables/useLpiHead.ts
+++ b/src/composables/useLpiHead.ts
@@ -1,6 +1,8 @@
+import useNuxtI18n from '@/composables/useNuxtI18n'
+
 export default (url, title, description, image, dimensions = null) => {
   const runtimeConfig = useRuntimeConfig()
-  const { locale } = useI18n()
+  const { locale } = useNuxtI18n()
 
   let imgMimeType = 'image/jpeg'
   if (image) {

--- a/src/composables/useNuxtI18n.ts
+++ b/src/composables/useNuxtI18n.ts
@@ -1,0 +1,18 @@
+// https://github.com/nuxt-modules/i18n/discussions/3027#discussioncomment-10384714
+
+import { useI18n } from 'vue-i18n'
+
+type i18N = ReturnType<typeof useI18n>
+/**
+ * use nuxt i18n insteadof vue18n (probleme render)
+ *
+ * @function
+ * @name useNuxtI18n
+ * @kind variable
+ * @returns {Composer<{ "en-US": LocaleMessage<VueMessageType>; }, { "en-US": DateTimeFormat; }, { "en-US": NumberFormat; }, string, "en-US", "en-US">}
+ */
+const useNuxtI18n = (): i18N => {
+  const nuxtApp = useNuxtApp()
+  return nuxtApp.$i18n as i18N
+}
+export default useNuxtI18n

--- a/src/pages/ProjectPageV2/ProjectPage.vue
+++ b/src/pages/ProjectPageV2/ProjectPage.vue
@@ -101,13 +101,10 @@ provide('projectLayoutProjectPatched', projectPatched)
 //     if (commentLoop.value) clearInterval(commentLoop.value)
 //     cleanupProvider()
 // })
-
-if (import.meta.server) {
-  try {
-    // project might need access right
-    const projectData = await getProject(route.params.slugOrId, true)
-    if (projectData) {
-      const { image, dimensions } = useImageAndDimension(projectData?.header_image, 'medium')
+const setLpiHead = (projectData) => {
+  if (projectData) {
+    const { image, dimensions } = useImageAndDimension(projectData?.header_image, 'medium')
+    try {
       useLpiHead(
         useRequestURL().toString(),
         projectData.title,
@@ -115,12 +112,24 @@ if (import.meta.server) {
         image,
         dimensions
       )
+    } catch (e) {
+      console.error(e)
     }
+  }
+}
+
+if (import.meta.server) {
+  try {
+    // project might need access right
+    const projectData = await getProject(route.params.slugOrId, true)
+    setLpiHead(projectData)
   } catch (err) {
     // DGAF
     console.log(err)
   }
 }
+// when project change, update header
+watch(project, setLpiHead)
 
 onMounted(async () => {
   if (import.meta.client) {


### PR DESCRIPTION
fix:
 - duplicate client request for `getProject` (now set Header only on server side)
 
 Better Optimization, run the query on server side, and for client re-use the data (no more fetch)